### PR TITLE
Add /.trae/ to .gitignore for Trae IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ yarn-error.log*
 
 # Kiro IDE
 /.kiro/
+
+# Trae IDE
+/.trae/


### PR DESCRIPTION
Adds /.trae/ to .gitignore to exclude Trae IDE files from ByteDance.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)