### PR TITLE
docs: reflect DreamWeave migration status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,31 @@
 # GroupWeave
 
-AI content generation is advancing at an incredible pace, leading to a significant shift in content creation and consumption.
+GroupWeave is the open infrastructure layer for user-owned AI experiences. The project empowers collaborative content creation and co-immersion across modalities, with NEAR as the first-chain deployment target and Shade agents extending into trusted execution environments.
 
-GroupWeave is the open-source infrastructure for user-owned AI, designed to enable co-creation and co-immersion in generative AI content. Currently developing on NEAR, with plans to integrate Shade agents as customizable, semi-autonomous assistants for multimodal content understanding, moderation, and curation.
+## Current Status (October 6, 2025)
 
-## Developer Contributions
+- Active app and smart contract development now resides in the private **DreamWeave** repository while we complete a comprehensive security audit.
+- The public `apps/*` workspaces remain as stubs; build, deploy, and contract commands are intentionally disabled until the audited code is re-open-sourced.
+- The `apps/creation`, `apps/dashboard`, and `apps/participation` Next.js projects have been merged into a single DreamWeave web experience. Updated sources will return to this repository after the audit deliverables are incorporated.
+- NEAR contracts previously tracked under `apps/contracts` were relocated for audit hardening. A sanitized reference implementation will be reintroduced here alongside audit notes.
+- Shared packages (`packages/ui`, `packages/common-types`, etc.) and infrastructure tooling continue to evolve in this monorepo, including documentation automation and agent-facing guidance.
 
-Please fork the repository, then create a branch and make the changes you wish to propose. Once the feature or fix is successfully implemented, resolve any conflicts with main locally. Finally, make a pull request and submit for review. Code contributions have to be approved by the maintainer(s), one at this time, and two when the project has grown. 
+## Working in This Repository
 
-## How to use
+While the application code is private, contributors can still collaborate on:
 
-Do not deploy any of the apps or smart contracts yet. The standards for merging will increase in a week. Please check back later in August.
+- Documentation updates (`docs.json`, `AGENTS.md`, `CLAUDE.md`) and developer onboarding flows.
+- Shared TypeScript packages and linting/formatting presets.
+- DevOps scaffolding (Turborepo tasks, pnpm scripts, Docker tooling) that does not expose private implementation details.
 
-This big project is developed as a monorepo with proper tooling, centralized documentation, and strict coding guidelines. Notes will be provided on conventions, AGENTS/CLAUDE.md, Docker, and Turborepo. AI agents should have a high efficacy with this setup.
+If you need to coordinate with the DreamWeave effort or request preview access during the audit window, please open an issue or reach out via the channels below.
+
+## Contribution Process
+
+1. Fork the repository and create a feature branch for documentation, tooling, or shared package improvements.
+2. Confirm that your changes do not rely on private DreamWeave assets.
+3. Ensure `pnpm lint`, `pnpm check-types`, and relevant tests pass for the packages you touched.
+4. Submit a pull request with conventional commit formatting. Maintainers will review for alignment with the audit timeline.
 
 ## Connect with us
 [![Website](https://readmecodegen.vercel.app/api/social-icon?name=Link)](https://www.torus-automations.xyz/)
@@ -34,8 +47,10 @@ When you make changes to the repository that require documentation updates (e.g.
 
 ## Roadmap
 
-The following features are currently being developed:
+The following priorities are in flight as part of the DreamWeave audit cycle:
 
-*   Betting as a mechanism for content curation/moderation with reward and punishment 
-*   User-owned AI and personalization with confidential AI models and trusted execution environments
-*   To be decided: Confidential voting/betting and tally counting with Zero Knowledge Proofs (ZKP)
+- Hardened launch of the merged DreamWeave web experience with modular content pipelines.
+- Security audit remediation for NEAR staking, voting, and ZKP verification contracts.
+- Expanded Shade agent integrations for confidential, user-owned inference paths.
+
+Once the audit closes, the corresponding applications and contracts will be re-synced here together with migration notes.

--- a/apps/contracts/README.md
+++ b/apps/contracts/README.md
@@ -1,119 +1,12 @@
-# NEAR Smart Contracts
+# NEAR Smart Contracts (Under Audit)
 
-This workspace contains the NEAR smart contracts for the GroupWeave platform.
+> **Status — October 6, 2025:** All production contract code now resides in the private DreamWeave repository for a comprehensive third-party security audit.
 
-## Structure
+The staking, voting, and ZKP verifier contracts previously tracked in `apps/contracts` were migrated to DreamWeave alongside the merged web experience. This directory remains as a placeholder until the audit report is finalized and the hardened implementations are cleared for re-release.
 
-```
-contracts/
-├── Cargo.toml          # Workspace manifest
-├── voting/             # 🗳️ Voting Contract
-│   ├── src/lib.rs
-│   └── Cargo.toml
-├── staking/            # 💰 Staking Contract
-│   ├── src/lib.rs
-│   └── Cargo.toml
-└── zkp-verifier/       # 🔒 ZKP Verifier Contract
-    ├── src/lib.rs
-    └── Cargo.toml
-```
+What to expect next:
+- Sanitized reference contracts, deployment scripts, and audit notes will be restored here after remediation is complete.
+- Issue tracking for contract features remains open, but pull requests should focus on documentation or tooling updates that do not expose private code.
+- We will publish migration guidance for node operators and integrators ahead of the public relaunch.
 
-## Contracts
-
-### Voting Contract
-Handles decentralized voting and polling functionality:
-- Create polls with multiple options
-- Vote on active polls
-- Track voting results
-- Time-limited polls
-- Vote changing capability
-
-### Staking Contract
-Manages token staking and rewards with flexible betting amounts:
-- Stake any amount of NEAR tokens within the contract's defined limits.
-- A minimum and maximum stake amount can be configured.
-- Earn rewards over time.
-- Unstake with reward claims.
-- Configurable reward rates and staking limits.
-
-### ZKP Verifier Contract
-Zero-knowledge proof verification:
-- Submit ZK proofs
-- Verify proofs with authorized verifiers
-- Store verification results
-- Simple hash-based proof verification
-
-## Development
-
-### Prerequisites
-- Rust 1.70+
-- NEAR CLI
-- cargo-near
-
-### Building
-```bash
-# Build all contracts
-cargo build --release
-
-# Build specific contract
-cargo build -p voting-contract --release
-```
-
-### Testing
-```bash
-# Run all tests
-cargo test
-
-# Test specific contract
-cargo test -p voting-contract
-```
-
-### Deployment
-```bash
-# Deploy voting contract
-near deploy --wasmFile target/wasm32-unknown-unknown/release/voting_contract.wasm --accountId your-contract.testnet
-
-# Deploy staking contract
-near deploy --wasmFile target/wasm32-unknown-unknown/release/staking_contract.wasm --accountId your-staking.testnet --initFunction new --initArgs '{"reward_rate": "10", "min_stake_amount": "1000000000000000000000000", "max_stake_amount": "100000000000000000000000000"}'
-
-# Deploy ZKP verifier contract
-near deploy --wasmFile target/wasm32-unknown-unknown/release/zkp_verifier_contract.wasm --accountId your-zkp.testnet
-```
-
-## Usage Examples
-
-### Voting Contract
-```bash
-# Create a poll
-near call your-contract.testnet create_poll '{"title": "Best Feature", "description": "Vote for the best feature", "options": ["Feature A", "Feature B", "Feature C"], "duration_minutes": 1440}' --accountId your-account.testnet
-
-# Vote on a poll
-near call your-contract.testnet vote '{"poll_id": 1, "option_index": 0}' --accountId your-account.testnet
-
-# Get poll results
-near view your-contract.testnet get_poll '{"poll_id": 1}'
-```
-
-### Staking Contract
-```bash
-# Stake tokens (e.g., 10 NEAR)
-near call your-staking.testnet stake --deposit 10 --accountId your-account.testnet
-
-# Check stake info
-near view your-staking.testnet get_stake_info '{"account": "your-account.testnet"}'
-
-# Claim rewards
-near call your-staking.testnet claim_rewards --accountId your-account.testnet
-
-# Update max stake amount (owner only)
-near call your-staking.testnet update_max_stake_amount '{"new_max_amount": "200000000000000000000000000"}' --accountId your-staking.testnet
-```
-
-### ZKP Verifier Contract
-```bash
-# Submit a proof
-near call your-zkp.testnet submit_proof '{"proof_id": "proof1", "proof_data": "base64_proof", "public_inputs": ["input1"], "verification_key": "vk_data"}' --accountId your-account.testnet
-
-# Verify a proof (authorized verifier only)
-near call your-zkp.testnet verify_proof '{"proof_id": "proof1", "is_valid": true}' --accountId verifier.testnet
-```
+Thank you for your patience while we certify the contracts for mainnet use.

--- a/apps/creation/README.md
+++ b/apps/creation/README.md
@@ -1,1 +1,12 @@
-DO NOT RUN ANY OF THESE YET!
+# Creation App (Placeholder)
+
+> **Status — October 6, 2025:** Active development of the GroupWeave creation surface now lives in the private DreamWeave monorepo while a security audit is underway.
+
+The former `apps/creation` Next.js project has been merged into the consolidated DreamWeave web experience that also serves dashboard and participation flows. The audited implementation will be re-synced to this repository once the review closes and the public launch plan is finalized.
+
+In the meantime:
+- Do not attempt to run, build, or deploy this workspace; the source is intentionally absent.
+- Track updates in this repository's main `README.md` and `AGENTS.md` files for re-opening milestones.
+- Submit documentation or tooling suggestions via issues or pull requests that do not rely on private DreamWeave code.
+
+Thank you for your patience while we harden the next release.

--- a/apps/dashboard/README.md
+++ b/apps/dashboard/README.md
@@ -1,1 +1,12 @@
-DO NOT RUN ANY OF THESE YET!
+# Dashboard App (Placeholder)
+
+> **Status — October 6, 2025:** The GroupWeave dashboard has moved into the private DreamWeave repository for a full security audit.
+
+The legacy dashboard, along with the creation and participation apps, now ships as a single DreamWeave web surface. We will restore an open-source snapshot here after the audit findings are addressed and the merged experience is ready for public release.
+
+Until then:
+- Avoid running or modifying this workspace; it intentionally contains no runnable code.
+- Watch `README.md` and project announcements for the re-open schedule.
+- File issues for documentation or tooling needs that can be resolved without exposing private DreamWeave assets.
+
+We appreciate the community's support during this transition.

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,1 +1,12 @@
-DO NOT RUN ANY OF THESE YET!
+# Documentation App (On Hold)
+
+> **Status — October 6, 2025:** The public documentation experience is being rebuilt alongside the DreamWeave consolidation and will return here after the ongoing security audit.
+
+While the creation, dashboard, and participation apps now live as a merged DreamWeave surface, the docs site is being updated to match the new architecture. This workspace intentionally ships without runnable code until the audited release is ready.
+
+In the interim:
+- Use the central `docs.json` + `generate_docs.py` flow in this repository for documentation changes.
+- Avoid attempting to run Next.js commands from this directory.
+- Track repository announcements for the refreshed documentation portal timeline.
+
+Community contributions to shared docs and tooling remain welcome.

--- a/apps/participation/README.md
+++ b/apps/participation/README.md
@@ -1,1 +1,12 @@
-DO NOT RUN ANY OF THESE YET!
+# Participation App (Placeholder)
+
+> **Status — October 6, 2025:** Participation flows are part of the unified DreamWeave web experience that is currently undergoing audit.
+
+This directory previously hosted a standalone Next.js app. It now acts as a placeholder while the merged DreamWeave experience (covering creation, dashboard, and participation journeys) is reviewed. Once the audit wraps and launch artifacts are finalized, we will publish an updated, open-source version here.
+
+For now:
+- Do not run, build, or expect source code inside this workspace.
+- Follow repository announcements for the reopen timeline.
+- Share documentation or tooling feedback through issues and PRs that do not require the private DreamWeave codebase.
+
+Thanks for helping us ship a hardened release.


### PR DESCRIPTION
## Summary
- refresh root README with the current DreamWeave migration status and contributor guidance
- replace web app readmes with placeholder messaging covering the merged DreamWeave surface
- update the contracts readme to flag the ongoing audit and future re-release plan

## Testing
- not run (docs only)
